### PR TITLE
Add Trezor to list of hardware wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@
 ## Hardware Wallets
 
 - [Ledger](https://www.ledgerwallet.com)
-- [Trezor](https://trezor.io/)
+- [Trezor](https://trezor.io)
 
 ## Paper Wallets
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 ## Hardware Wallets
 
 - [Ledger](https://www.ledgerwallet.com)
+- [Trezor](https://trezor.io/)
 
 ## Paper Wallets
 


### PR DESCRIPTION
Trezor works well for BCH and should be added to list of supporting hardware wallets for Bitcoin Cash