### PR TITLE
Added cashaddress.org to list of paper wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@
 
 ## Paper Wallets
 
+- [Cash Address](https://cashaddress.org)
 - [Bitcoin Paper Wallet](https://bitcoinpaperwallet.com)
 - [Bitaddress](https://www.bitaddress.org)
 


### PR DESCRIPTION
Just adds cashaddress.org to the paper wallets section. This one is updated with Bitcoin Cash resources and links.