### PR TITLE
Add Simple Pay to tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 
 # Tools
 - [SecretCoin](https://secretco.in)
+- [Simple Pay](http://www.bitcoinc.com.au/spay/)
 
 <br/>
 <br/>


### PR DESCRIPTION
Simple Pay is a tool to help merchants and users request a certain amount of payment from other users of Bitcoin Cash. The tool is apparently still be revised to add more features but already can be useful to the community.