### PR TITLE
Update API Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@
 
 ### APIs
 
-- [Bitcoin Cash](https://www.explorer.cash)
-- [Hashes](https://hashes.download/#api)
+- [Explorer.Cash *(coming soon)*](https://www.explorer.cash)
+- [Blockchair](https://github.com/Blockchair/Blockchair.Support/blob/master/API.md)
+- [BTC.com](https://bch.btc.com/api-doc#API)
 
 ### Real Time Stats
 


### PR DESCRIPTION
Summary of changes:
1. Removed [Hashes](https://hashes.download/#api), because there was no response from the server. I assume this service no longer exists.
2. Updated explorer.cash to indicate that the API isn't operational yet. I also updated the name of the link to match the name of the service.
3. Added Blockchair. Although their implementation isn't "production ready" for the public yet, it should still be useful for most people to sandbox. Should we indicate that in the link?
4. Added [BTC.com](https://bch.btc.com/api-doc#API).

Unfortunately while [Blockchain.info](https://blockchain.info/) wallets support BCH, their [API](https://blockchain.info/api) does not (yet). Similarly, [Blocktrail](https://blocktrail.com) has Bitcoin Cash listed on their website, however their [API](https://www.blocktrail.com/api/docs#api_data) does not yet support it ([shown here](https://www.blocktrail.com/api/docs#network)).